### PR TITLE
wraps __dirname with formatPathForModuleImport(__dirname)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,8 +34,8 @@
         "typescript": "^4.6.2"
       },
       "peerDependencies": {
-        "graphql": "^16.3.0",
-        "nexus": "^1.3.0"
+        "graphql": "^15 || ^16",
+        "nexus": "^1"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { plugin } from "nexus";
 import {
   ArgsValue,
   completeValue,
+  formatPathForModuleImport,
   MaybePromise,
   printedGenTyping,
   printedGenTypingImport,
@@ -140,7 +141,7 @@ export const argsValidatorPlugin = ({
         type: "ValidateResolver<TypeName, FieldName>",
         imports: [
           printedGenTypingImport({
-            module: join(__dirname, "."),
+            module: join(formatPathForModuleImport(__dirname), "."),
             bindings: ["ValidateResolver"],
           }),
         ],
@@ -152,7 +153,7 @@ export const argsValidatorPlugin = ({
         type: "TransformResolver<TypeName, FieldName>",
         imports: [
           printedGenTypingImport({
-            module: join(__dirname, "."),
+            module: join(formatPathForModuleImport(__dirname), "."),
             bindings: ["TransformResolver"],
           }),
         ],


### PR DESCRIPTION
This is a great plugin and does exactly what we need. So many thanks for your hard work!

However, when running graphql typegen, it produces an absolute path to the `nexus-args-validator/dist` folder instead of a relative path - which breaks things when sharing code with team members (as we all have different absolute paths on our file systems!)

This change seems to fix this issue.

Please consider this change.

Many thanks!